### PR TITLE
Changed _size in JsHexViewer to be initialized from slice size.

### DIFF
--- a/metal-tools-jshexviewer/src/main/java/nl/gertjanal/metaltools/jshexviewer/JsHexViewer.java
+++ b/metal-tools-jshexviewer/src/main/java/nl/gertjanal/metaltools/jshexviewer/JsHexViewer.java
@@ -186,7 +186,7 @@ public class JsHexViewer {
 		public Definition(final ParseValue value) {
 			_name = value.name;
 			_offset = value.slice.offset;
-			_size = value.getValue().length;
+			_size = value.slice.size;
 		}
 
 		@Override


### PR DESCRIPTION
This allows the vint fields to be highlight as a whole, not just the first byte, when the other bytes have only 0s.